### PR TITLE
Start from scratch with a new implementation

### DIFF
--- a/lib/ex_json_template/interpolation.ex
+++ b/lib/ex_json_template/interpolation.ex
@@ -16,28 +16,6 @@
 # limitations under the License.
 #
 
-defmodule ExJSONTemplate.MixProject do
-  use Mix.Project
-
-  def project do
-    [
-      app: :exjsontemplate,
-      version: "0.1.0",
-      elixir: "~> 1.8",
-      start_permanent: Mix.env() == :prod,
-      deps: deps()
-    ]
-  end
-
-  def application do
-    [
-      extra_applications: []
-    ]
-  end
-
-  defp deps do
-    [
-      {:exjsonpath, "~> 0.9.0"}
-    ]
-  end
+defmodule ExJSONTemplate.Interpolation do
+  defstruct [:tokens]
 end

--- a/lib/ex_json_template/operation.ex
+++ b/lib/ex_json_template/operation.ex
@@ -1,0 +1,24 @@
+#
+# This file is part of ExJSONTemplate.
+#
+# Copyright 2020 Ispirata Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule ExJSONTemplate.Operation do
+  defstruct [
+    :op,
+    :jsonpath
+  ]
+end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
 %{
-  "exjsonpath": {:hex, :exjsonpath, "0.9.0", "87e593eb0deb53aa0688ca9f9edc9fb3456aca83c82245f83201ea04d696feba", [:mix], [], "hexpm"},
+  "exjsonpath": {:hex, :exjsonpath, "0.9.0", "87e593eb0deb53aa0688ca9f9edc9fb3456aca83c82245f83201ea04d696feba", [:mix], [], "hexpm", "8d7a8e9ba784e1f7a67c6f1074a3ac91a3a79a45969514ee5d95cea5bf749627"},
 }

--- a/test/ex_json_template_test.exs
+++ b/test/ex_json_template_test.exs
@@ -51,31 +51,6 @@ defmodule ExJSONTemplateTest do
     assert ExJSONTemplate.render(compiled_template, map) == {:ok, expected_rendered}
   end
 
-  test "render placeholder using a map" do
-    {:ok, compiled_template} = ExJSONTemplate.compile_template("{{ $.data }}")
-
-    map = %{"data" => %{"1" => 1, "a" => "A"}}
-    assert ExJSONTemplate.render(compiled_template, map) == {:ok, %{"1" => 1, "a" => "A"}}
-  end
-
-  test "render map with placeholder using a map" do
-    template = %{"data" => %{"result" => "{{ $.data }}"}}
-    {:ok, compiled_template} = ExJSONTemplate.compile_template(template)
-
-    map = %{"data" => %{"1" => 1, "a" => "A"}}
-    expected_rendered = %{"data" => %{"result" => %{"1" => 1, "a" => "A"}}}
-    assert ExJSONTemplate.render(compiled_template, map) == {:ok, expected_rendered}
-  end
-
-  test "render array with placeholders using a map" do
-    template = ["{{ $.data.x }}", "{{ $.data.y }}", 0]
-    {:ok, compiled_template} = ExJSONTemplate.compile_template(template)
-
-    map = %{"data" => %{"x" => 0.5, "y" => -1.0, "t" => 5.3}}
-    expected_rendered = [0.5, -1.0, 0]
-    assert ExJSONTemplate.render(compiled_template, map) == {:ok, expected_rendered}
-  end
-
   test "render array with string interpolation using a map" do
     template = %{"data" => ["x: {{ $.x }}", "y: {{ $.y }}", "z: 0"]}
     {:ok, compiled_template} = ExJSONTemplate.compile_template(template)


### PR DESCRIPTION
Start with a new implementation with `{{ }}`, `{{{ }}}` and `{{& }}` support.