### PR TITLE
Add support to `#` (section) operator for lists/arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ Array templates can be written using `#` section operator:
 
 ```
 in: {"repo": [{"name": "Davide"}, {"name": "Riccardo"}]}
-t: {"{{#repo}}": "Hello {{ $.name }}"}
+t: {"{{#repo}}": "Hello {{ @.name }}"}
 out: ["Hello Davide", "Hello Riccardo"]
 ```
 
 ```
 in: {"repo": ["Davide", "Riccardo"]}
-t: {"{{#repo}}": "Hello {{ $ }}"}
+t: {"{{#repo}}": "Hello {{ @ }}"}
 out: ["Hello Davide", "Hello Riccardo"]
 ```
 
@@ -207,7 +207,7 @@ same way of an array single result (`[["foo", "bar"]]`).
 
 ```
 in: [{"user": "foo"}, %{"user" => "bar"}]
-t: {"{{# $..user }}": ["Hello {{ $ }}]}
+t: {"{{# $..user }}": "Hello {{ @ }}"}
 out: ["Hello foo", "Hello bar"]
 ```
 

--- a/lib/ex_json_template/section.ex
+++ b/lib/ex_json_template/section.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of ExJSONTemplate.
 #
-# Copyright 2020 Ispirata Srl
+# Copyright 2021 Ispirata Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,28 +16,9 @@
 # limitations under the License.
 #
 
-defmodule ExJSONTemplate.MixProject do
-  use Mix.Project
-
-  def project do
-    [
-      app: :exjsontemplate,
-      version: "0.1.0",
-      elixir: "~> 1.8",
-      start_permanent: Mix.env() == :prod,
-      deps: deps()
-    ]
-  end
-
-  def application do
-    [
-      extra_applications: []
-    ]
-  end
-
-  defp deps do
-    [
-      {:exjsonpath, github: "ispirata/exjsonpath"}
-    ]
-  end
+defmodule ExJSONTemplate.Section do
+  defstruct [
+    :jsonpath,
+    :template
+  ]
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
 %{
-  "exjsonpath": {:hex, :exjsonpath, "0.9.0", "87e593eb0deb53aa0688ca9f9edc9fb3456aca83c82245f83201ea04d696feba", [:mix], [], "hexpm", "8d7a8e9ba784e1f7a67c6f1074a3ac91a3a79a45969514ee5d95cea5bf749627"},
+  "exjsonpath": {:git, "https://github.com/ispirata/exjsonpath.git", "2e019eb30a7b214927ce1ec9b450dfc07a6f8e8d", []},
 }


### PR DESCRIPTION
Implement support to repated section application to a list of items.
This also makes use of `@` and JSONPath expressions starting with `@` as
a current item marker, opposed to `$` which is used for document root.